### PR TITLE
Do not find tars of scans

### DIFF
--- a/nexradaws/nexradawsinterface.py
+++ b/nexradaws/nexradawsinterface.py
@@ -158,6 +158,7 @@ class NexradAwsInterface(object):
                                                      Prefix=prefix,
                                                      Delimiter='/')
         for scan in resp.get('Contents'):
+            if scan.get('Key').endswith(".tar"): continue
             match = self._scan_re.match(scan.get('Key'))
             if match is not None:
                 scans.append(AwsNexradFile(scan))


### PR DESCRIPTION
AWS added tars of scans into some folders. If there a key ends with ".tar" lets skip it since this package does not handle them.