### PR TITLE
Fixes scan_re

### DIFF
--- a/nexradaws/nexradawsinterface.py
+++ b/nexradaws/nexradawsinterface.py
@@ -29,7 +29,7 @@ class NexradAwsInterface(object):
         self._month_re = re.compile(r'^\d{4}/(\d{2})')
         self._day_re = re.compile(r'^\d{4}/\d{2}/(\d{2})')
         self._radar_re = re.compile(r'^\d{4}/\d{2}/\d{2}/(....)/')
-        self._scan_re = re.compile(r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<station>....)/(?P=station)(?P=year)(?P=month)(?P=day)_\d{6}_V\d{2}.gz$')
+        self._scan_re =  re.compile(r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<station>....)/(?P=station)(?P=year)(?P=month)(?P=day)_\d{6}_(?:V\d{2})?(?:\.gz)?(?!\.tar)$')
         self._s3conn = boto3.resource('s3')
         self._s3conn.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
         self._bucket = self._s3conn.Bucket('noaa-nexrad-level2')

--- a/nexradaws/nexradawsinterface.py
+++ b/nexradaws/nexradawsinterface.py
@@ -29,7 +29,7 @@ class NexradAwsInterface(object):
         self._month_re = re.compile(r'^\d{4}/(\d{2})')
         self._day_re = re.compile(r'^\d{4}/\d{2}/(\d{2})')
         self._radar_re = re.compile(r'^\d{4}/\d{2}/\d{2}/(....)/')
-        self._scan_re = re.compile(r'^\d{4}/\d{2}/\d{2}/..../(?:(?=(.*.gz))|(?=(.*V0*.gz))|(?=(.*V0*)))')
+        self._scan_re = re.compile(r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<station>....)/(?P=station)(?P=year)(?P=month)(?P=day)_\d{6}_V\d{2}.gz$')
         self._s3conn = boto3.resource('s3')
         self._s3conn.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
         self._bucket = self._s3conn.Bucket('noaa-nexrad-level2')


### PR DESCRIPTION
the previous regex had some bugs that let it match the too many things
This changes it to match:
https://docs.opendata.aws/noaa-nexrad/readme.html


> All files in the archive use the same compressed format (.gz). The data file names are, for example, KAKQ20010101_080138.gz. The file naming convention is:
> 
> GGGGYYYYMMDD_TTTTTT
> 
> Where:
> 
> GGGG = Ground station ID (map of ground stations)
> YYYY = year
> MM = month
> DD = day
> TTTTTT = time when data started to be collected (GMT)
> Note that the 2015 files have an additional field on the file name. It adds “_V06” to the end of the file name. An example is KABX20150303_001050_V06.gz.

If any instances of scans in AWS that are not of this format, then this change could break some code. 